### PR TITLE
Alter suggested shortcut, and re-enable for Firefox.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Notice: in some editors you’ll need to run the _Enable GhostText_ command afte
 
 ### Keyboard shortcuts
 
-In Chrome, you can use a keyboard shortcut instead of clicking the button. You can also [change or disable](http://lifehacker.com/add-custom-keyboard-shortcuts-to-chrome-extensions-for-1595322121) the shortcut.
-
-Firefox [doesn’t support them yet.](https://github.com/GhostText/GhostText/issues/113)
+You can use a keyboard shortcut instead of clicking the button. The shortcut can be changed or disabled,
+[like this in Chrome](http://lifehacker.com/add-custom-keyboard-shortcuts-to-chrome-extensions-for-1595322121)
+or
+[like this in Firefox](https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox).
 
 <table>
   <tr>
@@ -49,15 +50,15 @@ Firefox [doesn’t support them yet.](https://github.com/GhostText/GhostText/iss
     <th>Shortcut</th>
   </tr>
   <tr>
-    <td>Chrome on Windows</td>
+    <td>Windows</td>
     <td><kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>K</kbd></td>
   </tr>
   <tr>
-    <td>Chrome on Linux</td>
+    <td>Linux</td>
     <td><kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>H</kbd></td>
   </tr>
   <tr>
-    <td>Chrome on Mac</td>
+    <td>Mac</td>
     <td><kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>K</kbd></td>
   </tr>
 </table>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "deploy": "npm run build && npm run update-version && npm run release-cws && npm run release-amo",
-    "release-amo": "cd browser && dot-json manifest.json commands --delete && webext submit",
+    "release-amo": "cd browser && webext submit",
     "release-cws": "cd browser && webstore upload --auto-publish",
     "update-version": "dot-json browser/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"
   }


### PR DESCRIPTION
Firefox now has a built-in UI for editing extension shortcuts, so we can
now re-enable the shortcut on Firefox, allowing users to update as they
wish.

Closes #147

The problematic shortcuts have been updated to Ctrl-Alt-E as suggested in #147

[when GhostText as a temporary extension as described in https://github.com/GhostText/GhostText/issues/147#issuecomment-496150163 neither the button nor the shortcut actually trigger the toggle properly, but that seems unrelated to this]