### PR TITLE
Don't short circuit AMO autodeploy when CWS fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
-    "deploy": "npm run build && npm run update-version && npm run release-cws && npm run release-amo",
+    "deploy": "npm run build && npm run update-version && npm run release-cws & npm run release-amo",
     "release-amo": "cd browser && webext submit",
     "release-cws": "cd browser && webstore upload --auto-publish",
     "update-version": "dot-json browser/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"


### PR DESCRIPTION
Firefox autodeploy currently short circuits without attempting whenever the Chrome webstore autodeploy fails.

See discussion here: https://github.com/GhostText/GhostText/pull/159#issuecomment-531398418