### PR TITLE
Fix Mozilla Add-ons deployment 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
-    "deploy": "npm run build && npm run update-version && run-p -c release-cws release-amo",
+    "deploy": "run-s build update-version --parallel --continue-on-error release-cws release-amo",
     "release-amo": "cd browser && webext submit",
     "release-cws": "cd browser && webstore upload --auto-publish",
     "update-version": "dot-json browser/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "devDependencies": {
     "chrome-webstore-upload-cli": "^1.0.0",
     "dot-json": "^1.0.3",
+    "npm-run-all": "^4.1.5",
     "typescript": "^1.8.10",
     "webext": "^1.9.1-with-submit.1"
   },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
-    "deploy": "npm run build && npm run update-version && npm run release-cws & npm run release-amo",
+    "deploy": "npm run build && npm run update-version && run-p -c release-cws release-amo",
     "release-amo": "cd browser && webext submit",
     "release-cws": "cd browser && webstore upload --auto-publish",
     "update-version": "dot-json browser/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"


### PR DESCRIPTION
# Setup

Browser: Firefox
Editor: Any

# Description
The autodeploy for Firefox AMO fails to package the inputarea.js file, now that it's been re-enabled as part of #159 and #160
Building the package from scrach using webext works on my machine. I'm not yet sure why the autodeploy artifact is missing this specific file.

You can reproduce this issue by loading the latest release from the AMO. The issue is fatal and prevents the extension from working entirely.