### PR TITLE
Don't ask for textarea if there is one already selected 

### DIFF
--- a/browser/scripts/content.js
+++ b/browser/scripts/content.js
@@ -231,15 +231,13 @@ function startGT() {
 		return;
 	}
 
-	// Blur focused element to allow selection with a click/focus
+  // If there's one element with focus, activate.
 	const focused = knownElements.get(document.activeElement);
 	if (focused) {
-		focused.field.blur();
-	}
-
+    focused.activate();
+  } else if (knownElements.size === 1) {
 	// If there's one element and it's not active, activate.
 	// If it's one and active, do nothing
-	if (knownElements.size === 1) {
 		if (activeFields.size === 0) {
 			const [field] = knownElements.values();
 			field.activate();

--- a/browser/scripts/content.js
+++ b/browser/scripts/content.js
@@ -231,11 +231,11 @@ function startGT() {
 		return;
 	}
 
-  // If there's one element with focus, activate.
+	// If there's one element with focus, activate.
 	const focused = knownElements.get(document.activeElement);
 	if (focused) {
-    focused.activate();
-  } else if (knownElements.size === 1) {
+		focused.activate();
+	} else if (knownElements.size === 1) {
 	// If there's one element and it's not active, activate.
 	// If it's one and active, do nothing
 		if (activeFields.size === 0) {


### PR DESCRIPTION
First of all, thanks for this wonderful extension! The concept is so simple and yet so powerful.

The new codebase (https://github.com/GhostText/GhostText/issues/172) is working great for me in Chrome + VimR.

But in applications with more than one textarea (like a search), the need to select the correct one with the mouse is annoying. It kind of ruins the purpose of having a keyboard shortcut. In my opinion, it makes sense that if you have already selected a textarea, you don't have to select it again.

If you don't want to make this the default, then please consider adding an option 🙂